### PR TITLE
Bug fix: right-edge column was zeroed out in deskewOneSection()

### DIFF
--- a/src/cudaSirecon/cudaSirecon.cpp
+++ b/src/cudaSirecon/cudaSirecon.cpp
@@ -503,14 +503,13 @@ void apodizationDriver(int zoffset, ReconParams* params,
 
     for (int z = 0; z < imgParams.nz; ++z) {
       for (int phase = 0; phase < params->nphases; ++phase) {
-        if (params->napodize >= 0) {
-          // Goes through here
+        if (params->napodize > 0) {
           apodize(params->napodize, imgParams.nx, imgParams.ny,
               &(rawImages->at(phase)),
               (z + zoffset) * (imgParams.nx/2 + 1)*2 * imgParams.ny);
         } else if (params->napodize == -1) {
           cosapodize(imgParams.nx, imgParams.ny, &(*rawImages)[phase],
-              (z + zoffset) * imgParams.nx * imgParams.ny);
+              (z + zoffset) * (imgParams.nx/2 +1)*2 * imgParams.ny);
         }
       } /* end for (phase), loading, flatfielding, and apodizing raw images */
     }
@@ -1749,7 +1748,7 @@ void deskewOneSection(CImg<> &rawSection, float* nxp2OutBuff, int z, int nz,
 
     for (int y=0; y<ny_in; y++) {
       unsigned indout = y * nx_out_ext + xout;
-      if (xin >= 0 && xin < nx_in-1) {
+      if (xin >= 0 && xin < nx_in) {
 
         unsigned indin = y * nx_in + (unsigned int) floor(xin);
 

--- a/src/cudaSirecon/gpuFunctionsImpl.cu
+++ b/src/cudaSirecon/gpuFunctionsImpl.cu
@@ -52,16 +52,15 @@ __host__ void apodize(int napodize, int nx,int ny, GPUBuffer* image,
 __global__ void apodize_x_kernel(int napodize, int nx, int ny,
     float* image)
 {
+  // This blends the top and bottom edges for column k
   int k = blockDim.x * blockIdx.x + threadIdx.x;
   int xdim = (nx/2+1) * 2;
   if (k < nx) {
     float diff = (image[(ny - 1) * xdim + k] - image[k]) / 2.0;
     for (int l = 0; l < napodize; ++l) {
-      float fact = 1.0 - sinf((((float)l + 0.5) / (float)napodize) *
-          M_PI * 0.5);
-      image[l * xdim + k] = image[l * xdim + k] + diff * fact;
-      image[(ny - 1 - l) * xdim + k] = image[(ny - 1 - l) * xdim + k] -
-        diff * fact;
+      float fact = 1.0 - sinf((l + 0.5) / (float)napodize * M_PI * 0.5);
+      image[l * xdim + k] += diff * fact;
+      image[(ny - 1 - l) * xdim + k] -=  diff * fact;
     }
   }
 }
@@ -69,16 +68,15 @@ __global__ void apodize_x_kernel(int napodize, int nx, int ny,
 __global__ void apodize_y_kernel(int napodize, int nx, int ny,
     float* image)
 {
+  // This blends the left and right edges for row l
   int l = blockDim.x * blockIdx.x + threadIdx.x;
   int xdim = (nx/2+1) * 2;
   if (l < ny) {
     float diff = (image[l * xdim + nx - 1] - image[l * xdim]) / 2.0;
     for (int k = 0; k < napodize; ++k) {
-      float fact = 1.0 - sinf(((k + 0.5) / (float)napodize) * M_PI *
-          0.5);
-      image[l * xdim + k] = image[l * xdim + k] + diff * fact;
-      image[l * xdim + (nx - 1 - k)] =
-        image[l * xdim + (nx - 1 - k)] - diff * fact;
+      float fact = 1.0 - sinf((k + 0.5) / (float)napodize * M_PI * 0.5);
+      image[l * xdim + k] += diff * fact;
+      image[l * xdim + (nx - 1 - k)] -= diff * fact;
     }
   }
 }


### PR DESCRIPTION
Fixed a bug in `deskewOneSection()`: zeroed out a column on the right edge by mistakenly comparing `xin < nx_in-1`; should be `xin < nx_in`.

Initially thought was a bug in input apodization, but it turns out to not be the case.

Should be an easy PR to approve. Thanks!