### PR TITLE
README updates and cosmetic code edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 Mats Gustafsson & Lin Shao's 3-beam SIM reconstruction software, with CUDA acceleration.
 
-Algorithm as described in [Gustafsson et al (2008) *Biophys*. **94(12)**: 4957–4970. doi: 10.1529/biophysj.107.120345](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2397368/)
+Algorithm as described in [Gustafsson et al (2008) *Biophys. J.* **94(12)**: 4957–4970. doi: 10.1529/biophysj.107.120345](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2397368/)
 
 
 ## Installation
 
-Packages for Linux and Windows *coming soon* on conda-forge:
+Packages for Linux and Windows on conda-forge:
 
 ```bash
 $ conda install -c conda-forge cudasirecon
@@ -17,7 +17,10 @@ $ conda create -n sim -y -c conda-forge cudasirecon
 $ conda activate sim
 ```
 
+In the examples shown above and below, *Shell* command line is used. The same works mostly in a Anaconda Prompt window on Windows, except for using`\`in place of`/`as the folder name dividers
+
 ## Usage
+### For`cudasirecon`
 
 ```bash
 # the binary will be available as
@@ -25,96 +28,25 @@ $ cudasirecon
 
 # for command line help
 $ cudasirecon --help
+# or:
+$ cudasirecon -h
 
 # a typical call for tiff files
-$ cudasirecon some/folder file_pattern otf.tif -c config
+$ cudasirecon some/folder file_pattern otf.tif -c config_file
 
 # a typical call for dv/mrc files
-$ cudasirecon data.dv data-PROC.dv otf.dv -c config
+$ cudasirecon data.dv data-proc.dv otf.dv -c config_file
 
-# ... where otf.otf was generated using the "makeotf" command:
-# note, makeotf not currently working/shipping on windows
-$ makeotf /path/to/psf.dv otf.dv -angle -1.855500 -ls 0.2075 -na 1.4 -nimm 1.515 -fixorigin 3 20 -leavekz 7 11 3
-
-# for more help on the makeotf command:
-$ makeotf -help
 ```
 
-### Full list of options/flags
-
-```txt
-$ cudasirecon --help
-
-  --input-file arg                  input file (or data folder in TIFF mode)
-  --output-file arg                 output file (or filename pattern in TIFF 
-                                    mode)
-  --otf-file arg                    OTF file
-  --usecorr arg                     use the flat-field correction file provided
-  --ndirs arg (=3)                  number of directions
-  --nphases arg (=5)                number of phases per direction
-  --nordersout arg (=0)             number of output orders; must be <= norders
-  --angle0 arg (=1.648)             angle of the first direction in radians
-  --ls arg (=0.172000006)           line spacing of SIM pattern in microns
-  --na arg (=1.20000005)            Detection numerical aperture
-  --nimm arg (=1.33000004)          refractive index of immersion medium
-  --zoomfact arg (=2)               lateral zoom factor
-  --explodefact arg (=1)            artificially exploding the reciprocal-space
-                                    distance between orders by this factor
-  --zzoom arg (=1)                  axial zoom factor
-  --nofilteroverlaps [=arg(=0)]     do not filter the overlaping region between
-                                    bands usually used in trouble shooting
-  --background arg (=0)             camera readout background
-  --wiener arg (=0.00999999978)     Wiener constant
-  --forcemodamp arg                 modamps forced to these values
-  --k0angles arg                    user given pattern vector k0 angles for all
-                                    directions
-  --otfRA [=arg(=1)]                using rotationally averaged OTF
-  --otfPerAngle [=arg(=1)]          using one OTF per SIM angle
-  --fastSI [=arg(=1)]               SIM data is organized in Z->Angle->Phase 
-                                    order; default being Angle->Z->Phase
-  --k0searchAll [=arg(=0)]          search for k0 at all time points
-  --norescale [=arg(=0)]            bleach correcting for z
-  --equalizez [=arg(=1)]            bleach correcting for z
-  --equalizet [=arg(=1)]            bleach correcting for time
-  --dampenOrder0 [=arg(=1)]         dampen order-0 in final assembly
-  --nosuppress [=arg(=0)]           do not suppress DC singularity in final 
-                                    assembly (good idea for 2D/TIRF data)
-  --nokz0 [=arg(=1)]                do not use kz=0 plane of the 0th order in 
-                                    the final assembly
-  --gammaApo arg (=1)               output apodization gamma; 1.0 means 
-                                    triangular apo
-  --saveprefiltered arg             save separated bands (half Fourier space) 
-                                    into a file and exit
-  --savealignedraw arg              save drift-fixed raw data (half Fourier 
-                                    space) into a file and exit
-  --saveoverlaps arg                save overlap0 and overlap1 (real-space 
-                                    complex data) into a file and exit
-  -c [ --config ] arg               name of a file of a configuration.
-  --2lenses [=arg(=1)]              I5S data
-  --bessel [=arg(=1)]               bessel-SIM data
-  --besselExWave arg (=0.488000005) Bessel SIM excitation wavelength in microns
-  --besselNA arg (=0.143999994)     Bessel SIM excitation NA)
-  --deskew arg (=0)                 Deskew angle; if not 0.0 then perform 
-                                    deskewing before processing
-  --deskewshift arg (=0)            If deskewed, the output image's extra shift
-                                    in X (positive->left)
-  --noRecon                         No reconstruction will be performed; useful
-                                    when combined with --deskew
-  --cropXY arg (=0)                 Crop the X-Y dimension to this number; 0 
-                                    means no cropping
-  --xyres arg (=0.100000001)        x-y pixel size (only used for TIFF files)
-  --zres arg (=0.200000003)         z pixel size (only used for TIFF files)
-  --zresPSF arg (=0.150000006)      z pixel size used in PSF TIFF files)
-  --wavelength arg (=530)           emission wavelength (only used for TIFF 
-                                    files)
-  --writeTitle [=arg(=1)]           Write command line to image header (may 
-                                    cause issues with bioformats)
-  -h [ --help ]                     produce help message
-```
-
-### Config file
-
-The config file can specify any flags/options listed above, and a typical 3D sim config file may look like this:
+#### Notes
+- `cudasirecon`should be supplied (unless to just display help message) with at least three arguments, which are interpreted differently depending on whether the input files are in TIFF or MRC/DV format:
+  - For MRC/DV format, the three arguments represent`input_file_name`,`output_file_name`, and `otf_file_name`in that order
+  - For TIFF format,  the three arguments represent `input_files_folder`,`pattern_shared_among_the_input_files`, and`otf_file_name`in that order; the output files are saved in a subfolder named `GPUsirecon` (subject to change) under `input_files_folder`
+  - The order of these three arguments, to be called *positional arguments* hereafter, is essential because their position determines how the program interprets them (unless a specific option names preceeds them; more on that below).
+  - The reason for such difference is that MRC/DV format usually stores a full time-series of 3D or 2D images in a single file, while in TIFF format typically each time point is saved in a separate TIFF file with a slightly different names from other files in the same series.
+- Besides these three arguments, `cudasirecon` is typically supplied with options or flags (a detailed list is below). For example `-ndirs 3` informs the program the number of SIM pattern angles; or `--bessel` to inform that the data was acquired in lattice-light-sheet mode. All options that require an argument have a default setting if that option is not specified (for example one can skip the `-ndirs 3` option because that's the default). There is no rules on ordering of the options/flags and they can appear either before or after or even in-between the three positional arguments.
+- The `-c` or `--config` option allows using a config file (as demo'ed in the above Shell scipt) to specify multiple options, with one`option_name=option_value`pair per each line and the choices for`option_name`are the same as the command-line option names (the long form preceded with`--`). An example 3D SIM config file may look like this:
 
 ```bash
 nimm=1.515
@@ -129,6 +61,112 @@ na=1.42
 otfRA=1
 dampenOrder0=1
 ```
+
+- OTF files are converted from PSF files using`makeotf`program also included in this package; more on its usage below.
+
+
+### Full list of options/flags for`cudasirecon`
+
+```txt
+$ cudasirecon --help
+Usage:
+ cudasirecon [--options] [option-arguments] input_file(or folder) output_file(or file name pattern) otf_file
+
+ List of options:
+  --input-file arg            input file name (or data folder in TIFF mode)
+  --output-file arg           output file name (or filename pattern in TIFF mode)
+  --otf-file arg              OTF file name
+  -c [ --config ] arg         name of a config file with parameters in place of command-line options
+  --ndirs arg (=3)            number of SIM  directions
+  --nphases arg (=5)          number of pattern phases per SIM direction
+  --nordersout arg (=0)       number of output SIM orders (must be <= nphases//2; safe to ignore usually)
+  --angle0 arg (=1.648)       angle of the first SIM angle in radians
+  --ls arg (=0.172)           line spacing of SIM pattern in microns
+  --na arg (=1.2)             detection objective's numerical aperture
+  --nimm arg (=1.33)          refractive index of immersion medium
+  --wiener arg (=0.01)        Wiener constant; lower value leads to higher resolution and noise;
+                              playing with it extensively is strongly encouraged
+  --zoomfact arg (=2)         lateral zoom factor in the output over the input images;
+                              leaving it at 2 should be fine in most cases
+  --zzoom arg (=1)            axial zoom factor; almost never needed
+  --background arg (=0)       camera readout background
+  --usecorr arg               use a flat-field correction file if provided
+  --forcemodamp arg           modamps to be forced to these values; useful when
+                              image quality is low and auto-estimated modamps 
+                              are below, say, 0.1
+  --k0angles arg              user these pattern vector k0 angles for all 
+                              directions (instead of inferring the rest agnles 
+                              from angle0)
+  --otfRA                     using rotationally averaged OTF; otherwise using 
+                              3/2D OTF for 3/2D raw data
+  --otfPerAngle               using one OTF per SIM angle; otherwise one OTF is
+                              used for all angles, which is how it's been done 
+                              traditionally
+  --fastSI                    SIM image is organized in Z->Angle->Phase order; 
+                              otherwise assuming Angle->Z->Phase image order
+  --k0searchAll [=arg(=0)]    search for k0 at all time points
+  --norescale [=arg(=0)]      no bleach correction
+  --equalizez                 bleach correction for z
+  --equalizet                 bleach correction for time
+  --dampenOrder0              dampen order-0 in final assembly; do not use for 2D SIM; good choice for high-background images
+  --nosuppress [=arg(=0)]     do not suppress DC singularity in the result (good choice for 2D/TIRF data)
+  --nokz0                     not using kz=0 plane of the 0th order in the final assembly (mostly for debug)
+  --gammaApo arg (=1)         output apodization gamma; 1.0 means triangular 
+                              apo; lower value means less dampening of 
+                              high-resolution info at the tradeoff of higher 
+                              noise
+  --explodefact arg (=1)      artificially exploding the reciprocal-space 
+                              distance between orders by this factor (for debug)
+  --nofilterovlps [=arg(=0)]  not filtering the overlaping region between bands (for debug)
+  --saveprefiltered arg       save separated bands (half Fourier space) into a file and exit (for debug)
+  --savealignedraw arg        save drift-fixed raw data (half Fourier space) into a file and exit (for debug)
+  --saveoverlaps arg          save overlap0 and overlap1 (real-space complex data) into a file and exit (for debug)
+  --2lenses                   I5S data
+  --bessel                    bessel-SIM data
+  --besselExWave arg (=0.488) Bessel SIM excitation wavelength in microns
+  --besselNA arg (=0.144)     Bessel SIM excitation NA)
+  --deskew arg (=0)           Deskew angle; if not 0.0 then perform deskewing before processing
+  --deskewshift arg (=0)      If deskewed, the output image's extra shift in X (positive->left)
+  --noRecon                   No reconstruction will be performed; useful when combined with --deskew
+  --cropXY arg (=0)           Crop the X-Y dimension to this number; 0 means no cropping
+  --xyres arg (=0.1)          x-y pixel size (only used for TIFF files)
+  --zres arg (=0.2)           z pixel size (only used for TIFF files)
+  --zresPSF arg (=0.15)       z pixel size used in PSF TIFF files)
+  --wavelength arg (=530)     emission wavelength in nanometers (only used for TIFF files)
+  --writeTitle                Write command line to MRC/DV header (may cause issues with bioformats)
+  -h [ --help ]               produce help message
+  --version                   show version
+
+```
+
+#### Notes on the essential flags
+- `--ndirs`and `--nphases` informs the program of the number of SIM angles and phases within each angle, respectively.
+- `--ls`, `--angle0` (or `--k0angles`) inform the program of a good estimation on the SIM pattern's line spacing (in &#x00B5;m) and angles (in radians). If using `--angle0`, then the rest of the angles are successively incremented by &#x03C0;/`ndirs`; if using `--k0angles` then list all angles in order and separated by commas without any space.
+- `--wiener`specifies the Wiener constant that balances between resolution and amplified noise artifact. The lower it is, the higher the resolution but also more amplified-noise-related artifacts and vice versa. 
+- `--background`informs the estimated background level of the input images. The camera's dark image's mean intensity would be a good guess to start with. Too high of a background value supplied can be fatal to the reconstruction result.
+- `--otfRA` is needed if rotationally averaged OTF is used
+- `--fastSI`is needed if Z->Angle->Phase acquisition order is used
+- For lattice-light-sheet SIM, one would need the `--bessel` flag and might want to specify the following flags: `--besselNA`, `--besselNA`, `--deskew`, `--deskewshift`
+
+### For`makeotf`
+The utility of `makeotf` is to generate rotationally averaged OTFs for all SIM orders. The input to it is a single-direction SIM data set acquire with one point-like object as the sample. In general this OTF can be used for reconstructing multi-angle SIM data.
+
+```
+# And example of how to call makeotf:
+
+$ makeotf /path/to/psf.dv otf.dv -angle -1.855500 -ls 0.2075 -na 1.4 -nimm 1.515 -fixorigin 3 20 -leavekz 7 11 3
+
+# The example above shows practically all flags that are needed for generating a 3D SIM OTF; if 2D SIM or LLSM-SIM you should skip the last two flags.
+```
+#### Essential flags
+
+- `-fixorigin`takes two integers (>0) as arguments. Purpose of this flag is to suppress the singularity of order-0 (i.e., wide-field) 3D OTF at the origin by extrapolating the OTF's amplitudes between those pixels along the k<sub>r</sub> axis toward the origin and use that value in the end result. 3 and 20 are in general good for PSFs obtained with at least 256x256 pixels
+ - **Do not** supply this option to process LLSM-SIM PSFs, as the issue with origin singularity is much less severe.
+- `-leavekz`takes three integers as arguments. Purpose of this flag is to zero out the region outside of the OTF support. The first two numbers correspond to the two pixels on the positive k<sub>z</sub> axis of the order-1 OTF, between which the order-1 OTF support intersects the k<sub>z</sub> axis. The third number corresponds to a pixel on the positive k<sub>z</sub> axis, between which and the origin the order-2 OTF support intersects the k<sub>z</sub> axis. With these other related numbers such as NA and wavelengths, the program could calculate what's inside and what's outside the OTF supports and then zero out the outside parts.
+ - To get these numbers right, it usually requires trial and error approach and examining the OTF output to see if the carving-out makes sense.
+ - In TIFF mode, along with the OTF file the program also outputs a companion TIFF file, whose name contains `OnlyForViewing`, that can be easily opened to examine the OTF.
+ - **Do not** supply this option to process LLSM-SIM PSFs, as the OTF supports are not well defined geometrically.
+
 
   
 ## GPU requirements

--- a/src/cudaSirecon/boostfs.cpp
+++ b/src/cudaSirecon/boostfs.cpp
@@ -8,8 +8,16 @@ static boost::filesystem::path outputDir;
 
 std::vector<std::string> gatherMatchingFiles(std::string target_path, std::string pattern)
 {
+  // Check if the pattern is specified as a full file name (i.e.; if '.tif' is in the name)
+  size_t p1 = pattern.rfind(".tif");
+  size_t p2 = pattern.rfind(".TIF");
+  if (p1 != std::string::npos || p2 != std::string::npos) {
+    // if no matches were found, rfind() returns 'string::npos'
+    // do not append ".*tif" at the end of pattern
+  }
+  else
+    pattern.append(".*\\.[tT][iI][fF]");
   pattern.insert(0, ".*");  // '.' is the wildcard in Perl regexp; '*' just means "repeat".
-  pattern.append(".*\\.tif");
 
   const std::regex my_filter(pattern);
 

--- a/src/cudaSirecon/cudaSireconImpl.h
+++ b/src/cudaSirecon/cudaSireconImpl.h
@@ -105,40 +105,40 @@ struct ReconParams {
   float k0startangle, linespacing;
   float na, nimm;
   int   ndirs, nphases, norders_output;
-  int norders;
+  int   norders;
   float *phaseSteps; /** user-specified non-ideal phase steps, one for each orientation */
-  int   bTwolens;    /** whether to process I{^5}S dataset */
-  int   bFastSIM;   /** fast SIM data is organized differently */
-  int   bBessel;    /** whether to process Bessel-Sheet SIM dataset */
+  bool  bTwolens;    /** whether to process I{^5}S dataset */
+  bool  bFastSIM;   /** fast SIM data is organized differently */
+  bool  bBessel;    /** whether to process Bessel-Sheet SIM dataset */
   float BesselNA;  /* excitation NA of the Bessel beam */
   float BesselLambdaEx; /* excitation wavelength of the Bessel beam */
   float deskewAngle; /* Beseel-sheet sample scan angle */
-  int extraShift; // If deskewed, the output image's extra shift in X
+  int   extraShift; // If deskewed, the output image's extra shift in X
   bool  bNoRecon; // whether not to reconstruct; used usually when deskewing
   unsigned cropXYto; // crop the X-Y dimension to this size; 0 means no cropping
-  int   bWriteTitle;   /** whether to write command line args to title field in mrc header */
+  bool  bWriteTitle;   /** whether to write command line args to title field in mrc header */
 
   /* algorithm related parameters */
-  float  zoomfact;
+  float zoomfact;
   int   z_zoom;
   int   nzPadTo;  /** pad zero sections to this number of z sections */
-  float  explodefact;
-  int   bFilteroverlaps;
+  float explodefact;
+  bool  bFilteroverlaps;
   int   recalcarrays; /** whether to calculate the overlaping regions between bands just once or always; used in fitk0andmodamps() */
   int   napodize;
   int   bSearchforvector;
   int   bUseTime0k0;   /** whether to use time 0's k0 fit for the rest of a time series */
   int   apodizeoutput;  /** 0-no apodize; 1-cosine apodize; 2-triangle apodize; used in filterbands() */
-  float  apoGamma;
+  float apoGamma;
   int   bSuppress_singularities;  /** whether to dampen the OTF values near band centers; used in filterbands() */
   int   suppression_radius;   /** if suppress_singularities is 1, the range within which suppresion is applied; used in filterbands() */
-  int   bDampenOrder0;  /** whether to dampen the OTF values near band centers; used in filterbands() */
+  bool  bDampenOrder0;  /** whether to dampen the OTF values near band centers; used in filterbands() */
   int   bFitallphases;  /** In NL SIM, whether to use fitted phase for all orders or to infer higher order phase from order 1 phase fil */
   int   do_rescale; /** fading correction method: 0-no correction; 1-with correction */
-  int   equalizez;
-  int   equalizet;
-  int   bNoKz0;   /** if true, no kz=0 plane is used in modamp fit and assemblerealspace() */
-  float  wiener, wienerInr;
+  bool  equalizez;
+  bool  equalizet;
+  bool  bNoKz0;   /** if true, no kz=0 plane is used in modamp fit and assemblerealspace() */
+  float wiener, wienerInr;
   // // int   bUseEstimatedWiener;
   std::vector<float> forceamp;
   // float *k0angles;
@@ -148,8 +148,8 @@ struct ReconParams {
   int   nxotf, nyotf, nzotf;
   float dzPSF;    /** PSF's z step size (for non-MRC formats) */
   float dkzotf, dkrotf;  /** OTF's pixel size in inverse mirons */
-  int   bRadAvgOTF;   /** is radially-averaged OTF used? */
-  int   bOneOTFperAngle; /** one OTF per SIM angle (instead of common OTF for all angles)?*/
+  bool  bRadAvgOTF;   /** is radially-averaged OTF used? */
+  bool  bOneOTFperAngle; /** one OTF per SIM angle (instead of common OTF for all angles)?*/
 
   /* drift correction and phase step correction related flags */
   int   bFixdrift;   /** whether nor not to correct drift between pattern directions */

--- a/src/cudaSirecon/gpuFunctionsImpl.cu
+++ b/src/cudaSirecon/gpuFunctionsImpl.cu
@@ -1285,7 +1285,7 @@ __host__ void filterbands(int dir, std::vector<GPUBuffer>* bands,
 
   for (order=0;order<norders;order++) {
     if (zdistcutoff[order]>=nz/2) zdistcutoff[order]=((nz/2-1) > 0 ? (nz/2-1) : 0);
-    /* printf("order=%d, rdistcutoff=%f, zdistcutoff=%d\n", order, rdistcutoff, zdistcutoff[order]); */
+    // printf("order=%d, rdistcutoff=%f, zdistcutoff=%d\n", order, rdistcutoff, zdistcutoff[order]);
   }
 
   float apocutoff = rdistcutoff+ k0mag * (norders-1);
@@ -1390,7 +1390,7 @@ __host__ void filterbands(int dir, std::vector<GPUBuffer>* bands,
       dev_bandptr = (cuFloatComplex*)bands->at(0).getPtr();
     }
     else {
-      dev_bandptr = (cuFloatComplex*)bands->at(2*order-1).getPtr();     /* bands contains only the data of one direction -- dir*/
+      dev_bandptr = (cuFloatComplex*)bands->at(2*order-1).getPtr();
       dev_bandptr2 = (cuFloatComplex*)bands->at(2*order).getPtr();
     }
 
@@ -1443,7 +1443,7 @@ __host__ void filterbands(int dir, std::vector<GPUBuffer>* bands,
 
 __global__ void filterbands_kernel1(int dir, int ndirs, int order, int norders, int nx, int ny, 
 									int nz, float rdistcutoff, float zapocutoff, float apocutoff, float dxy, float kzscale,
-    cuFloatComplex * dev_bandptr, cuFloatComplex * dev_bandptr2, bool bSecondEntry)
+									cuFloatComplex * dev_bandptr, cuFloatComplex * dev_bandptr2, bool bSecondEntry)
 {
 
   float kx, ky, rdist1, rdistabs, apofact;

--- a/src/cudaSirecon/gpuFunctionsImpl_hh.cu
+++ b/src/cudaSirecon/gpuFunctionsImpl_hh.cu
@@ -30,8 +30,7 @@ __constant__ int const_pParams_nzotf;
 __constant__ float const_pParams_dkrotf;
 __constant__ float const_wiener;
 
-/** These data are not modified in the kernels and can go in constant
- * memory */
+/** These data are not modified in the kernels and can go in constant memory */
 __constant__ int const_zdistcutoff[3];
 __constant__ float const_ampmag2[3];
 __constant__ float const_ampmag2_alldirs[9];


### PR DESCRIPTION
- Cosmetic changes to the code:
1. makeotf now outputs a amplitude-only OTF TIFF files for quick check;
2. '.tif' can now be in the file name search pattern
3. polishing program_options/flags in cudaSirecon.cpp