### PR TITLE
- Changed the type of "__constant__ const_pParams_bBessel" from int t…

### DIFF
--- a/src/cudaSirecon/cudaSirecon.cpp
+++ b/src/cudaSirecon/cudaSirecon.cpp
@@ -28,6 +28,7 @@ void SetDefaultParams(ReconParams *pParams)
   pParams->bBessel = false;
   pParams->BesselNA = 0.45;
 
+  pParams->otfcutoff = 0.006;
   pParams->zoomfact = 2;
   pParams->z_zoom = 1;
   pParams->nzPadTo = 0;
@@ -936,6 +937,8 @@ int SIM_Reconstructor::setupProgramOptions()
      "refractive index of immersion medium")
     ("wiener", po::value<float>(&m_myParams.wiener)->default_value(0.01, "0.01"),
      "Wiener constant; lower value leads to higher resolution and noise; playing with it extensively is strongly encouraged")
+    ("otfcutoff", po::value<float>(&m_myParams.otfcutoff)->default_value(0.006, "0.006"),
+     "otf threshold below which it'll be considered noise and not used in makeoverlaps")
     ("zoomfact", po::value<float>(&m_myParams.zoomfact)->default_value(2.),
      "lateral zoom factor in the output over the input images; leaving it at 2 should be fine in most cases")
     ("zzoom", po::value<int>(&m_myParams.z_zoom)->default_value(1),

--- a/src/cudaSirecon/cudaSireconImpl.h
+++ b/src/cudaSirecon/cudaSireconImpl.h
@@ -119,6 +119,7 @@ struct ReconParams {
   bool  bWriteTitle;   /** whether to write command line args to title field in mrc header */
 
   /* algorithm related parameters */
+  float otfcutoff; /** below which OTF value will be deemed as noise and not used in makeoverlaps*/
   float zoomfact;
   int   z_zoom;
   int   nzPadTo;  /** pad zero sections to this number of z sections */

--- a/src/cudaSirecon/gpuFunctionsImpl.cu
+++ b/src/cudaSirecon/gpuFunctionsImpl.cu
@@ -550,7 +550,7 @@ __host__ void makeoverlaps(std::vector<GPUBuffer>* bands,
 
   float kx = k0x * (order2 - order1);
   float ky = k0y * (order2 - order1);
-  float otfcutoff = 0.008;
+  float otfcutoff = params->otfcutoff;
   if (params->bBessel)
     otfcutoff = 0.01;
 
@@ -573,7 +573,7 @@ __host__ void makeoverlaps(std::vector<GPUBuffer>* bands,
   cutilSafeCall(cudaMemcpyToSymbol(const_pParams_apodizeoutput,
         &params->apodizeoutput, sizeof(int)));
   cutilSafeCall(cudaMemcpyToSymbol(const_pParams_bBessel,
-        &params->bBessel, sizeof(int)));
+        &params->bBessel, sizeof(bool)));
   cutilSafeCall(cudaMemcpyToSymbol(const_pParams_bRadAvgOTF,
         &params->bRadAvgOTF, sizeof(int)));
   cutilSafeCall(cudaMemcpyToSymbol(const_pParams_nzotf,
@@ -1322,8 +1322,7 @@ __host__ void filterbands(int dir, std::vector<GPUBuffer>* bands,
         &pParams->apodizeoutput, sizeof(int)));
   cutilSafeCall(cudaMemcpyToSymbol(const_pParams_apoGamma,
         &pParams->apoGamma, sizeof(float)));
-  cutilSafeCall(cudaMemcpyToSymbol(const_pParams_bBessel,
-        &pParams->bBessel, sizeof(int)));
+  cutilSafeCall(cudaMemcpyToSymbol(const_pParams_bBessel, &pParams->bBessel, sizeof(bool)));
   cutilSafeCall(cudaMemcpyToSymbol(const_pParams_bRadAvgOTF,
         &pParams->bRadAvgOTF, sizeof(int)));
   cutilSafeCall(cudaMemcpyToSymbol(const_pParams_nzotf, &pParams->nzotf,

--- a/src/cudaSirecon/gpuFunctionsImpl_hh.cu
+++ b/src/cudaSirecon/gpuFunctionsImpl_hh.cu
@@ -24,7 +24,7 @@ __constant__ int const_pParams_bNoKz0;
 __constant__ int const_pParams_bFilteroverlaps;
 __constant__ int const_pParams_apodizeoutput;
 __constant__ float const_pParams_apoGamma;
-__constant__ int const_pParams_bBessel;
+__constant__ bool const_pParams_bBessel;
 __constant__ int const_pParams_bRadAvgOTF;
 __constant__ int const_pParams_nzotf;
 __constant__ float const_pParams_dkrotf;


### PR DESCRIPTION
Changed the type of "__constant__ const_pParams_bBessel" from int to bool after noticing a bug where bBessel is interpreted in CUDA as TRUE even though it should be FALSE

- Added a flag "--otfcutoff" to replace the hard-coded value in makeoverlaps()