### PR TITLE
Update config-tiff in test_data

### DIFF
--- a/test_data/config-tiff
+++ b/test_data/config-tiff
@@ -1,5 +1,5 @@
 nimm=1.515
-fastSI=1
+fastSI=0
 background=0
 wiener=0.001
 k0angles=0.804300,1.8555,-0.238800


### PR DESCRIPTION
The test data is not in the fast-SIM format and thus `fastSI` should be set to 0.